### PR TITLE
Feature/switch-to-redis

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,3 +20,5 @@ cop:
 
 links:
   duration: 48h
+  length: 8
+  padding: 2

--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,9 @@ log:
 db:
   url: db_url
 
+redis:
+  url: redis_url
+
 listener:
   addr: :8000
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible
 	github.com/ethereum/go-ethereum v1.13.5
 	github.com/go-chi/chi v4.1.2+incompatible
+	github.com/redis/go-redis/v9 v9.3.1
 	github.com/rubenv/sql-migrate v1.5.2
 	gitlab.com/distributed_lab/ape v1.7.1
 	gitlab.com/distributed_lab/kit v1.11.2
@@ -14,7 +15,9 @@ require (
 
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/holiman/uint256 v1.2.3 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -19,11 +19,15 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
 github.com/certifi/gocertifi v0.0.0-20200211180108-c7c1fbc02894 h1:JLaf/iINcLyjwbtTsCJjc6rtlASgHeIJPrB6QmwURnA=
 github.com/certifi/gocertifi v0.0.0-20200211180108-c7c1fbc02894/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
@@ -39,6 +43,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeC
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
@@ -173,6 +179,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
+github.com/redis/go-redis/v9 v9.3.1 h1:KqdY8U+3X6z+iACvumCNxnoluToB+9Me+TvyFa21Mds=
+github.com/redis/go-redis/v9 v9.3.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rubenv/sql-migrate v1.5.2 h1:bMDqOnrJVV/6JQgQ/MxOpU+AdO8uzYYA/TxFUBzFtS0=
 github.com/rubenv/sql-migrate v1.5.2/go.mod h1:H38GW8Vqf8F0Su5XignRyaRcbXbJunSWxs+kmzlg0Is=

--- a/internal/config/links.go
+++ b/internal/config/links.go
@@ -11,6 +11,8 @@ import (
 
 type LinksConfig struct {
 	Duration time.Duration `fig:"duration"`
+	Length   int           `fig:"length"`
+	Padding  int           `fig:"padding"`
 }
 
 type Links interface {
@@ -32,6 +34,8 @@ func (l *links) LinksConfig() *LinksConfig {
 	return l.once.Do(func() interface{} {
 		config := &LinksConfig{
 			Duration: time.Hour * 24,
+			Length:   8,
+			Padding:  2,
 		}
 		raw := kv.MustGetStringMap(l.getter, "links")
 		if err := figure.Out(config).From(raw).Please(); err != nil {

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -14,6 +14,7 @@ type Config interface {
 	types.Copuser
 	comfig.Listenerer
 	Links
+	Redis
 }
 
 type config struct {
@@ -23,6 +24,7 @@ type config struct {
 	comfig.Listenerer
 	getter kv.Getter
 	Links
+	Redis
 }
 
 func New(getter kv.Getter) Config {
@@ -33,5 +35,6 @@ func New(getter kv.Getter) Config {
 		Listenerer: comfig.NewListenerer(getter),
 		Logger:     comfig.NewLogger(getter, comfig.LoggerOpts{}),
 		Links:      NewLinks(getter),
+		Redis:      NewRedis(getter),
 	}
 }

--- a/internal/config/redis.go
+++ b/internal/config/redis.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"context"
+
+	redis2 "github.com/redis/go-redis/v9"
+	"gitlab.com/distributed_lab/figure"
+	"gitlab.com/distributed_lab/kit/comfig"
+	"gitlab.com/distributed_lab/kit/kv"
+	"gitlab.com/distributed_lab/logan/v3/errors"
+)
+
+type redisConfig struct {
+	URL string `fig:"url,required"`
+}
+
+type Redis interface {
+	RedisClient() *redis2.Client
+}
+
+func NewRedis(getter kv.Getter) Redis {
+	return &redis{
+		getter: getter,
+	}
+}
+
+type redis struct {
+	getter kv.Getter
+	once   comfig.Once
+}
+
+func (r *redis) readConfig() redisConfig {
+	config := redisConfig{}
+
+	err := figure.Out(&config).
+		From(kv.MustGetStringMap(r.getter, "redis")).
+		Please()
+	if err != nil {
+		panic(errors.Wrap(err, "failed to figure out redis"))
+	}
+
+	return config
+}
+
+func (r *redis) RedisClient() *redis2.Client {
+	return r.once.Do(func() interface{} {
+		config := r.readConfig()
+
+		opts, err := redis2.ParseURL(config.URL)
+		if err != nil {
+			panic(errors.Wrap(err, "failed to parse redis url"))
+		}
+
+		cli := redis2.NewClient(opts)
+		_, err = cli.Ping(context.Background()).Result()
+		if err != nil {
+			panic(errors.Wrap(err, "failed to ping redis database"))
+		}
+
+		return cli
+	}).(*redis2.Client)
+}

--- a/internal/config/redis.go
+++ b/internal/config/redis.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"time"
 
 	redis2 "github.com/redis/go-redis/v9"
 	"gitlab.com/distributed_lab/figure"
@@ -52,7 +53,10 @@ func (r *redis) RedisClient() *redis2.Client {
 		}
 
 		cli := redis2.NewClient(opts)
-		_, err = cli.Ping(context.Background()).Result()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+
+		_, err = cli.Ping(ctx).Result()
 		if err != nil {
 			panic(errors.Wrap(err, "failed to ping redis database"))
 		}

--- a/internal/data/links.go
+++ b/internal/data/links.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 )
@@ -8,16 +9,14 @@ import (
 type LinksQ interface {
 	New() LinksQ
 
-	Get() (*Link, error)
+	Get(ctx context.Context, id string) (*Link, error)
 
-	Insert(data Link) (*Link, error)
-
-	FilterByID(id ...string) LinksQ
+	Insert(ctx context.Context, data Link) (*Link, error)
 }
 
 type Link struct {
-	ID        string          `db:"id" structs:"id"`
-	ExpiredAt time.Time       `db:"expired_at" structs:"expired_at"`
-	Value     json.RawMessage `db:"value" structs:"value"`
-	Path      string          `db:"path" structs:"path"`
+	ID        string          `db:"id" structs:"id" json:"id"`
+	ExpiredAt time.Time       `db:"expired_at" structs:"expired_at" json:"expired_at"`
+	Value     json.RawMessage `db:"value" structs:"value" json:"value"`
+	Path      string          `db:"path" structs:"path" json:"path"`
 }

--- a/internal/data/redis/links.go
+++ b/internal/data/redis/links.go
@@ -1,0 +1,54 @@
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/dl-solarity/frontend-link-shortener-svc/internal/data"
+	"github.com/redis/go-redis/v9"
+)
+
+type linksQ struct {
+	client *redis.Client
+}
+
+func NewLinksQ(client *redis.Client) data.LinksQ {
+	return &linksQ{client: client}
+}
+
+func (q *linksQ) New() data.LinksQ {
+	return NewLinksQ(q.client)
+}
+
+func (q *linksQ) Get(ctx context.Context, id string) (*data.Link, error) {
+	val, err := q.client.Get(ctx, id).Result()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var link data.Link
+	err = json.Unmarshal([]byte(val), &link)
+	if err != nil {
+		return nil, err
+	}
+
+	return &link, nil
+}
+
+func (q *linksQ) Insert(ctx context.Context, value data.Link) (*data.Link, error) {
+	val, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+
+	err = q.client.Set(ctx, value.ID, val, value.ExpiredAt.Sub(time.Now())).Err()
+	if err != nil {
+		return nil, err
+	}
+
+	return &value, nil
+}

--- a/internal/service/handlers/create_link.go
+++ b/internal/service/handlers/create_link.go
@@ -28,7 +28,7 @@ func CreateLink(w http.ResponseWriter, r *http.Request) {
 	linksCfg := Links(r)
 	linkData := newLinkData(request, linksCfg)
 
-	link, err := LinksQ(r).Insert(*linkData)
+	link, err := LinksQ(r).Insert(r.Context(), *linkData)
 	if err != nil {
 		Log(r).WithError(err).Error("failed to create a link")
 		ape.RenderErr(w, problems.InternalError())

--- a/internal/service/handlers/create_link.go
+++ b/internal/service/handlers/create_link.go
@@ -13,11 +13,6 @@ import (
 	"gitlab.com/distributed_lab/ape/problems"
 )
 
-const (
-	linkLength = 8
-	padding    = 2
-)
-
 func CreateLink(w http.ResponseWriter, r *http.Request) {
 	request, err := requests.NewCreateLinkRequest(r)
 	if err != nil {
@@ -45,9 +40,10 @@ func CreateLink(w http.ResponseWriter, r *http.Request) {
 func newLinkData(request requests.CreateLinkRequest, config config.LinksConfig) *data.Link {
 	path, value := request.Data.Attributes.Path, request.Data.Attributes.Value
 	linkHash := getHash(getHash(path) + getHash(string(value)))
+	length, padding := config.Length, config.Padding
 
 	return &data.Link{
-		ID:        linkHash[padding : padding+linkLength],
+		ID:        linkHash[padding : padding+length],
 		ExpiredAt: time.Now().Add(config.Duration).UTC(),
 		Value:     value,
 		Path:      path,

--- a/internal/service/handlers/get_data.go
+++ b/internal/service/handlers/get_data.go
@@ -16,7 +16,7 @@ func GetData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	link, err := LinksQ(r).FilterByID(request.Link).Get()
+	link, err := LinksQ(r).Get(r.Context(), request.Link)
 	if err != nil {
 		Log(r).WithError(err).Error("failed to get a link")
 		ape.RenderErr(w, problems.InternalError())

--- a/internal/service/main.go
+++ b/internal/service/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/dl-solarity/frontend-link-shortener-svc/internal/config"
+	"github.com/redis/go-redis/v9"
 	"gitlab.com/distributed_lab/kit/copus/types"
 	"gitlab.com/distributed_lab/kit/pgdb"
 	"gitlab.com/distributed_lab/logan/v3"
@@ -16,6 +17,7 @@ type service struct {
 	copus       types.Copus
 	listener    net.Listener
 	db          *pgdb.DB
+	rdb         *redis.Client
 	linksConfig *config.LinksConfig
 }
 
@@ -36,6 +38,7 @@ func newService(cfg config.Config) *service {
 		copus:       cfg.Copus(),
 		listener:    cfg.Listener(),
 		db:          cfg.DB(),
+		rdb:         cfg.RedisClient(),
 		linksConfig: cfg.LinksConfig(),
 	}
 }

--- a/internal/service/main.go
+++ b/internal/service/main.go
@@ -16,8 +16,8 @@ type service struct {
 	log         *logan.Entry
 	copus       types.Copus
 	listener    net.Listener
-	db          *pgdb.DB
-	rdb         *redis.Client
+	db          func() *pgdb.DB
+	rdb         func() *redis.Client
 	linksConfig *config.LinksConfig
 }
 
@@ -37,8 +37,8 @@ func newService(cfg config.Config) *service {
 		log:         cfg.Log(),
 		copus:       cfg.Copus(),
 		listener:    cfg.Listener(),
-		db:          cfg.DB(),
-		rdb:         cfg.RedisClient(),
+		db:          cfg.DB,
+		rdb:         cfg.RedisClient,
 		linksConfig: cfg.LinksConfig(),
 	}
 }

--- a/internal/service/router.go
+++ b/internal/service/router.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"github.com/dl-solarity/frontend-link-shortener-svc/internal/data/pg"
+	"github.com/dl-solarity/frontend-link-shortener-svc/internal/data/redis"
 	"github.com/dl-solarity/frontend-link-shortener-svc/internal/service/handlers"
 	"github.com/go-chi/chi"
 	"gitlab.com/distributed_lab/ape"
@@ -15,7 +15,7 @@ func (s *service) router() chi.Router {
 		ape.LoganMiddleware(s.log),
 		ape.CtxMiddleware(
 			handlers.CtxLog(s.log),
-			handlers.CtxLinksQ(pg.NewLinksQ(s.db)),
+			handlers.CtxLinksQ(redis.NewLinksQ(s.rdb)),
 			handlers.CtxLinks(*s.linksConfig),
 		),
 	)

--- a/internal/service/router.go
+++ b/internal/service/router.go
@@ -15,7 +15,7 @@ func (s *service) router() chi.Router {
 		ape.LoganMiddleware(s.log),
 		ape.CtxMiddleware(
 			handlers.CtxLog(s.log),
-			handlers.CtxLinksQ(redis.NewLinksQ(s.rdb)),
+			handlers.CtxLinksQ(redis.NewLinksQ(s.rdb())),
 			handlers.CtxLinks(*s.linksConfig),
 		),
 	)


### PR DESCRIPTION
This PR adds:
- Redis config and `LinksQ` implementation
- State pruning aka automatic deletion of expired links; Redis allows to specify TTL when inserting

`LinksQ` implementation for Postgresql is still there until we make sure we only need Redis